### PR TITLE
bug fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.6.21'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -20,7 +20,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -34,7 +34,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 17
     }
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:showOnLockScreen="true"
             android:launchMode="singleTask"
             android:exported="true"
+            android:process="co.airhost.flutter_callkit_incoming"
             android:theme="@style/CallkitIncomingTheme">
             <intent-filter>
                 <action android:name="com.hiennv.flutter_callkit_incoming.ACTION_CALL_INCOMING" />

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/AppUtils.java
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/AppUtils.java
@@ -1,0 +1,77 @@
+package com.hiennv.flutter_callkit_incoming;
+
+import android.app.ActivityManager;
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.util.Log;
+
+import java.util.List;
+
+class AppUtils {
+    /**
+     * 提交代码后，设置为false
+     */
+    private final static boolean isPrintLog = false;
+
+    /**
+     * Identify if the application is currently in a state where user interaction is possible. This
+     * method is called when a remote message is received to determine how the incoming message should
+     * be handled.
+     *
+     * @param context context.
+     * @return True if the application is currently in a state where user interaction is possible,
+     * false otherwise.
+     */
+    static boolean isApplicationForeground(Context context) {
+        KeyguardManager keyguardManager =
+                (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+
+        if (keyguardManager != null && keyguardManager.isKeyguardLocked()) {
+            return false;
+        }
+
+        ActivityManager activityManager =
+                (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        if (activityManager == null) {
+            return false;
+        }
+
+        List<ActivityManager.RunningAppProcessInfo> appProcesses =
+                activityManager.getRunningAppProcesses();
+        if (appProcesses == null) {
+            return false;
+        }
+
+        final String packageName = context.getPackageName();
+        for (ActivityManager.RunningAppProcessInfo appProcess : appProcesses) {
+            if (appProcess.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+                    && appProcess.processName.equals(packageName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isFlutterAppKilled() {
+        FlutterCallkitIncomingPlugin plugin = FlutterCallkitIncomingPlugin.Companion.getInstance();
+        if (null != plugin) {
+            return plugin.isMainActivityKilled();
+        }
+        logger("null == plugin");
+        return true;
+    }
+
+    static void logger(String msg) {
+        if (isPrintLog) {
+            Log.e("callkit", msg);
+        }
+    }
+
+    static void logger(String msg, Throwable tr) {
+        if (isPrintLog) {
+            Log.e("callkit", msg, tr);
+        }
+    }
+
+}

--- a/lib/flutter_callkit_incoming.dart
+++ b/lib/flutter_callkit_incoming.dart
@@ -13,6 +13,8 @@ class FlutterCallkitIncoming {
       const MethodChannel('flutter_callkit_incoming');
   static const EventChannel _eventChannel =
       const EventChannel('flutter_callkit_incoming_events');
+  static const EventChannel _specificEventChannel =
+      const EventChannel('flutter_callkit_specific_events');
 
   /// Listen to event callback from [FlutterCallkitIncoming].
   ///
@@ -33,6 +35,15 @@ class FlutterCallkitIncoming {
   /// }
   static Stream<CallEvent?> get onEvent =>
       _eventChannel.receiveBroadcastStream().map(_receiveCallEvent);
+
+  /// Listen to event callback from [FlutterCallkitIncoming].
+  ///
+  /// FlutterCallkitIncoming.onSpecificEvent.listen((event) {
+  /// CallEvent.ACTION_CALL_DECLINE - Declined an incoming call
+  /// CallEvent.ACTION_CALL_ENDED - Ended an incoming/outgoing call
+  /// }
+  static Stream<CallEvent?> get onSpecificEvent =>
+      _specificEventChannel.receiveBroadcastStream().map(_receiveCallEvent);
 
   /// Show Callkit Incoming.
   /// On iOS, using Callkit. On Android, using a custom UI.


### PR DESCRIPTION
## Description:
- bug fix:
- 增加了单独的event channel来专门支持:flutter app处于杀死状态,发送挂断通知
- 不能使用老的channel是因为: flutter app被杀死,flutter只能在firebase message background里面监听老channel,这会导致在CallKit接听电话时,被这里监听到了. 但是这里无法调用flutter的任何方法.
- 为全屏通知activity增加了process name,解决flutter收不到后台消息.

## Basecamp To-Do URL:

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my codes locally
- [x] New and existing unit tests pass locally with my changes, if applicable