### PR TITLE
[Abel] fix: [P3][Staff]Staff can not display the call reminder page when the app running in background and closed screen

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:process="co.airhost.flutter_callkit_incoming"
             android:theme="@style/CallkitIncomingTheme">
             <intent-filter>
-                <action android:name="com.hiennv.flutter_callkit_incoming.ACTION_CALL_INCOMING" />
+                <action android:name="${applicationId}.com.hiennv.flutter_callkit_incoming.ACTION_CALL_INCOMING" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
@@ -33,11 +33,11 @@
             android:enabled="true"
             android:exported="true">
             <intent-filter>
-                <action android:name="com.hiennv.flutter_callkit_incoming.ACTION_CALL_INCOMING" />
-                <action android:name="com.hiennv.flutter_callkit_incoming.ACTION_CALL_ACCEPT" />
-                <action android:name="com.hiennv.flutter_callkit_incoming.ACTION_CALL_DECLINE" />
-                <action android:name="com.hiennv.flutter_callkit_incoming.ACTION_CALL_ENDED" />
-                <action android:name="com.hiennv.flutter_callkit_incoming.ACTION_CALL_TIMEOUT" />
+                <action android:name="${applicationId}.com.hiennv.flutter_callkit_incoming.ACTION_CALL_INCOMING" />
+                <action android:name="${applicationId}.com.hiennv.flutter_callkit_incoming.ACTION_CALL_ACCEPT" />
+                <action android:name="${applicationId}.com.hiennv.flutter_callkit_incoming.ACTION_CALL_DECLINE" />
+                <action android:name="${applicationId}.com.hiennv.flutter_callkit_incoming.ACTION_CALL_ENDED" />
+                <action android:name="${applicationId}.com.hiennv.flutter_callkit_incoming.ACTION_CALL_TIMEOUT" />
             </intent-filter>
         </receiver>
 

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -50,12 +50,12 @@ import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Comp
 class CallkitIncomingActivity : Activity() {
 
     companion object {
-
+        lateinit var appContext: Context;
         const val ACTION_ENDED_CALL_INCOMING =
             "com.hiennv.flutter_callkit_incoming.ACTION_ENDED_CALL_INCOMING"
 
         fun getIntent(data: Bundle) = Intent(ACTION_CALL_INCOMING).apply {
-            action = ACTION_CALL_INCOMING
+            action =appContext.packageName +"."+ ACTION_CALL_INCOMING
             putExtra(EXTRA_CALLKIT_INCOMING_DATA, data)
             flags =
                 Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -58,43 +58,43 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
 
         fun getIntentIncoming(context: Context, data: Bundle?) =
                 Intent(context, CallkitIncomingBroadcastReceiver::class.java).apply {
-                    action = ACTION_CALL_INCOMING
+                    action = context.packageName+"."+ ACTION_CALL_INCOMING
                     putExtra(EXTRA_CALLKIT_INCOMING_DATA, data)
                 }
 
         fun getIntentStart(context: Context, data: Bundle?) =
                 Intent(context, CallkitIncomingBroadcastReceiver::class.java).apply {
-                    action = ACTION_CALL_START
+                    action =  context.packageName+"."+ACTION_CALL_START
                     putExtra(EXTRA_CALLKIT_INCOMING_DATA, data)
                 }
 
         fun getIntentAccept(context: Context, data: Bundle?) =
                 Intent(context, CallkitIncomingBroadcastReceiver::class.java).apply {
-                    action = ACTION_CALL_ACCEPT
+                    action =  context.packageName+"."+ACTION_CALL_ACCEPT
                     putExtra(EXTRA_CALLKIT_INCOMING_DATA, data)
                 }
 
         fun getIntentDecline(context: Context, data: Bundle?) =
                 Intent(context, CallkitIncomingBroadcastReceiver::class.java).apply {
-                    action = ACTION_CALL_DECLINE
+                    action = context.packageName+"."+ ACTION_CALL_DECLINE
                     putExtra(EXTRA_CALLKIT_INCOMING_DATA, data)
                 }
 
         fun getIntentEnded(context: Context, data: Bundle?) =
                 Intent(context, CallkitIncomingBroadcastReceiver::class.java).apply {
-                    action = ACTION_CALL_ENDED
+                    action = context.packageName+"."+ ACTION_CALL_ENDED
                     putExtra(EXTRA_CALLKIT_INCOMING_DATA, data)
                 }
 
         fun getIntentTimeout(context: Context, data: Bundle?) =
                 Intent(context, CallkitIncomingBroadcastReceiver::class.java).apply {
-                    action = ACTION_CALL_TIMEOUT
+                    action = context.packageName+"."+ ACTION_CALL_TIMEOUT
                     putExtra(EXTRA_CALLKIT_INCOMING_DATA, data)
                 }
 
         fun getIntentCallback(context: Context, data: Bundle?) =
                 Intent(context, CallkitIncomingBroadcastReceiver::class.java).apply {
-                    action = ACTION_CALL_CALLBACK
+                    action = context.packageName+"."+ ACTION_CALL_CALLBACK
                     putExtra(EXTRA_CALLKIT_INCOMING_DATA, data)
                 }
     }
@@ -108,7 +108,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         AppUtils.logger(
             "广播收到的 action：$action, detect:${AppUtils.isFlutterAppKilled()}"
         )
-        when (action) {
+        when (action.removePrefix(context.packageName+".")) {
             ACTION_CALL_INCOMING -> {
                 try {
                     callkitNotificationManager.showIncomingNotification(data)

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/FlutterCallkitIncomingPlugin.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/FlutterCallkitIncomingPlugin.kt
@@ -78,6 +78,7 @@ class FlutterCallkitIncomingPlugin : FlutterPlugin, MethodCallHandler, ActivityA
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         this.context = flutterPluginBinding.applicationContext
+        CallkitIncomingActivity.appContext = flutterPluginBinding.applicationContext
         callkitNotificationManager = CallkitNotificationManager(flutterPluginBinding.applicationContext)
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_callkit_incoming")
         channel?.setMethodCallHandler(this)


### PR DESCRIPTION
## Description:

## Basecamp To-Do URL:
[[P3][Staff]Staff can not display the call reminder page when the app running in background and closed screen](https://3.basecamp.com/3708673/buckets/20297196/todos/5384101863/edit?replace=true)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my codes locally
- [ ] I have change pubspec.yaml