### PR TITLE
[rex] fix: when orientation change will send duplicate message to flutter

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
             </intent-filter>
         </activity>
         <activity
+            android:configChanges="navigation|orientation|screenSize|keyboard|keyboardHidden|fontScale|mnc|mcc"
             android:exported="false"
             android:theme="@style/TranslucentTheme"
             android:name="com.hiennv.flutter_callkit_incoming.TransparentActivity"/>

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/AppUtils.java
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/AppUtils.java
@@ -7,7 +7,7 @@ import android.util.Log;
 
 import java.util.List;
 
-class AppUtils {
+public class AppUtils {
     /**
      * 提交代码后，设置为false
      */

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -255,6 +255,7 @@ class CallkitIncomingActivity : Activity() {
         animateAcceptCall()
 
         ivAcceptCall.setOnClickListener {
+            AppUtils.logger("ACTION_CALL_ACCEPT Clicked ivAcceptCall")
             onAcceptClick()
         }
         ivDeclineCall.setOnClickListener {
@@ -278,9 +279,11 @@ class CallkitIncomingActivity : Activity() {
             intent?.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
         if (intent != null) {
+            AppUtils.logger("ACTION_CALL_ACCEPT onAcceptClick - startActivities()")
             val intentTransparent = TransparentActivity.getIntentAccept(this@CallkitIncomingActivity, data)
             startActivities(arrayOf(intent, intentTransparent))
         } else {
+            AppUtils.logger("ACTION_CALL_ACCEPT onAcceptClick - sendBroadcast()")
             val acceptIntent = CallkitIncomingBroadcastReceiver.getIntentAccept(this@CallkitIncomingActivity, data)
             sendBroadcast(acceptIntent)
         }

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -145,7 +145,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
                     if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
                         WorkManager.getInstance(context).cancelAllWork()
                     }
-                    AppUtils.logger("ACTION_CALL_ACCEPT")
+                    AppUtils.logger("ACTION_CALL_ACCEPT SendEvent")
                     sendEventFlutter(ACTION_CALL_ACCEPT, data)
                     context.stopService(Intent(context, CallkitSoundPlayerService::class.java))
                     callkitNotificationManager.clearIncomingNotification(data)

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
@@ -355,6 +355,7 @@ class CallkitNotificationManager(private val context: Context) {
         val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.cloneFilter()
         intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         if (intent != null) {
+            AppUtils.logger("ACTION_CALL_ACCEPT getAcceptPendingIntent - getActivities()")
             val intentTransparent = TransparentActivity.getIntentAccept(context, data)
             return PendingIntent.getActivities(
                     context,
@@ -363,6 +364,7 @@ class CallkitNotificationManager(private val context: Context) {
                     getFlagPendingIntent()
             )
         } else {
+            AppUtils.logger("ACTION_CALL_ACCEPT getAcceptPendingIntent - getBroadcast()")
             val acceptIntent = CallkitIncomingBroadcastReceiver.getIntentAccept(context, data)
             return PendingIntent.getBroadcast(
                     context,

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/TransparentActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/TransparentActivity.kt
@@ -3,8 +3,8 @@ package com.hiennv.flutter_callkit_incoming
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
-import android.util.Log
 
 class TransparentActivity : Activity() {
 
@@ -38,8 +38,10 @@ class TransparentActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        when (intent.getStringExtra("type")) {
+        val type = intent.getStringExtra("type")
+        when (type) {
             "ACCEPT" -> {
+                AppUtils.logger("ACTION_CALL_ACCEPT onCreate - sendBroadcast(ACCEPT)")
                 val data = intent.getBundleExtra("data")
                 val acceptIntent = CallkitIncomingBroadcastReceiver.getIntentAccept(this@TransparentActivity, data)
                 sendBroadcast(acceptIntent)
@@ -50,6 +52,7 @@ class TransparentActivity : Activity() {
                 sendBroadcast(acceptIntent)
             }
             else -> { // Note the block
+                AppUtils.logger("ACTION_CALL_ACCEPT onCreate - default - sendBroadcast($type)")
                 val data = intent.getBundleExtra("data")
                 val acceptIntent = CallkitIncomingBroadcastReceiver.getIntentAccept(this@TransparentActivity, data)
                 sendBroadcast(acceptIntent)
@@ -57,5 +60,10 @@ class TransparentActivity : Activity() {
         }
         finish()
         overridePendingTransition(0, 0)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        AppUtils.logger("ACTION_CALL_ACCEPT onConfigurationChanged - newConfig: $newConfig")
     }
 }


### PR DESCRIPTION
## Basecamp To-Do URL:
[[P3][Tablet][Intercom]When IOS tablet calls Android tablet, toast "The call has been accepted by another device"](https://3.basecamp.com/3708673/buckets/20297196/todos/5534889777)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my codes locally
- [ ] I have change pubspec.yaml